### PR TITLE
When using unified android sysroot include platform specific headers with explicit path

### DIFF
--- a/avbuild.sh
+++ b/avbuild.sh
@@ -385,7 +385,7 @@ use armv6t2 or -mthumb-interwork: https://gcc.gnu.org/onlinedocs/gcc-4.5.3/gcc/A
     if [ "$USE_TOOLCHAIN" = "clang" ]; then
       EXTRA_CFLAGS="$EXTRA_CFLAGS -iwithsysroot /usr/include/$ANDROID_HEADER_TRIPLE"
     else
-      EXTRA_CFLAGS="$EXTRA_CFLAGS -isystem=/usr/include/$ANDROID_HEADER_TRIPLE"
+      EXTRA_CFLAGS="$EXTRA_CFLAGS -isystem \$NDK_ROOT/$ANDROID_SYSROOT_REL/usr/include/$ANDROID_HEADER_TRIPLE"
     fi
   else
     ANDROID_SYSROOT_REL=${ANDROID_SYSROOT_LIB_REL}


### PR DESCRIPTION
This fixes the Android GCC build on Windows hosts using Msys2 (Problems with C:/ != /c/)