### PR TITLE
恢复默认优化级别

### DIFF
--- a/config-lite.sh
+++ b/config-lite.sh
@@ -1,4 +1,4 @@
-USER_OPT="--enable-small --disable-avresample \
+USER_OPT="--disable-avresample \
 --disable-filters \
 --enable-filter=*fade,*fifo,*format,*resample,aeval,all*,atempo,color*,convolution,draw*,eq*,framerate,hw*,null,volume \
 --disable-muxers \


### PR DESCRIPTION
我感觉如果单纯是为了减小二进制文件的大小，去除那些不常用的编解码器就足够了，大小已经能减小很多了，不必更改优化级别，为大小优化（O1）和为速度优化（O2）对文件的大小影响不大。此外，启用LTCG/LTO也能减小二进制文件的大小而不会影响它的性能。

PS. 我不清楚您是如何编译MDK的，不过我也不建议使用O1优化，损失了性能但对文件大小的影响不大，建议开启LTCG/LTO，在进一步优化的同时还能减小文件大小。